### PR TITLE
fix_deploied_error_of_channel

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,5 +1,5 @@
-# module ApplicationCable
-  # class Connection < ActionCable::Connection::Base
+ module ApplicationCable
+   class Connection < ActionCable::Connection::Base
     # identified_by :current_user
 
    #def connect
@@ -14,5 +14,5 @@
           # reject_unauthorized_connection
         # end
       # end
-  # end
-# end
+   end
+ end


### PR DESCRIPTION
## 概要
* デプロイ時に以下のエラーが出たため対処しました。
 raise Zeitwerk::NameError.new(msg, cref.last)

